### PR TITLE
Pass through wellknown to timeout callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "byu-wabs-oauth",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -190,7 +190,7 @@ async function getTokenEndpoints (wellKnown) {
   // set cache timeout
   wellKnownTimeoutId = setTimeout(() => {
     debug.wellKnown('cache expired')
-    getTokenEndpoints()
+    getTokenEndpoints(wellKnown)
       .catch(err => {
         debug.wellKnown('unable to refresh well known information')
         console.error(err.stack)


### PR DESCRIPTION
- fix: pass through wellknown url to timeout callback
- 4.0.6
